### PR TITLE
ブログ詳細ページを表示できるようにした

### DIFF
--- a/src/content/blog/template/index.mdx
+++ b/src/content/blog/template/index.mdx
@@ -14,7 +14,7 @@ import image from './sample.webp';
 
 # {frontmatter.title}
 
-# 1. 見出し（Headers）
+# 見出し（Headers）
 
 # 最大見出し
 
@@ -28,7 +28,7 @@ import image from './sample.webp';
 
 ###### 最小見出し
 
-# 2. 強調 (Emphasis)
+# 強調 (Emphasis)
 
 _斜体_
 _斜体_
@@ -36,7 +36,7 @@ _斜体_
 **太字**
 **太字と*斜体*の混在**
 
-# 3. リスト (Lists)
+# リスト (Lists)
 
 ## 番号付きリスト
 
@@ -51,11 +51,11 @@ _斜体_
   - サブアイテム
 - リストアイテム3
 
-# 4. リンク (Links)
+# リンク (Links)
 
 [Google](https://www.google.com)
 
-# 5. 画像 (Images)
+# 画像 (Images)
 
 ## Imageコンポーネントを利用
 
@@ -65,12 +65,12 @@ _斜体_
 
 ![代替テキスト](https://dummyimage.com/600x400/000/fff)
 
-# 6. 引用 (Blockquotes)
+# 引用 (Blockquotes)
 
 > 引用文  
 > これは引用セクションです。
 
-# 7. コード (Code)
+# コード (Code)
 
 ## インラインコード
 

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -48,6 +48,14 @@ const { title } = Astro.props;
     src: url('@/assets/fonts/NotoSansJP-Bold.woff2') format('woff2');
   }
 
+  html {
+    scroll-behavior: smooth;
+    scroll-padding-top: 100px;
+    @media (width<=768px) {
+      scroll-padding-top: 150px;
+    }
+  }
+
   body {
     font-family: NotoSansJP, 'Hiragino Kaku Gothic ProN', 'ヒラギノ角ゴ ProN W3',
       'メイリオ', Meiryo, 'ＭＳ ゴシック', sans-serif;

--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -1,0 +1,48 @@
+---
+import { type CollectionEntry, getCollection } from 'astro:content';
+import Layout from '@/layouts/Layout.astro';
+import TOC from './_components/TOC/index.astro';
+import Title from './_components/Title/index.astro';
+
+export async function getStaticPaths() {
+  const posts = await getCollection('blog');
+  return posts.map((post) => ({
+    params: { slug: post.slug },
+    props: post,
+  }));
+}
+
+type Props = CollectionEntry<'blog'>;
+
+const post = Astro.props;
+const { Content, headings } = await post.render();
+---
+
+<Layout title="ブログ">
+  <main>
+    <Title
+      title={post.data.title}
+      createdAt={post.data.createdAt}
+      updatedAt={post.data.updatedAt}
+      category={post.data.category}
+      tags={post.data.tags}
+    />
+    <div class="content-wrapper">
+      <div class="content">
+        <TOC headings={headings} />
+        <Content />
+      </div>
+    </div>
+  </main>
+</Layout>
+
+<style is:global lang="scss">
+  .content-wrapper {
+    padding: 2rem 4rem;
+    background-color: map-get($colors, 'white');
+
+    @media screen and (width <= 768px) {
+      padding: 1rem 2rem;
+    }
+  }
+</style>

--- a/src/pages/posts/_components/TOC/index.astro
+++ b/src/pages/posts/_components/TOC/index.astro
@@ -1,0 +1,104 @@
+---
+import type { MarkdownHeading } from 'astro';
+
+type Props = {
+  headings: MarkdownHeading[];
+};
+
+const { headings } = Astro.props;
+console.dir(headings, { depth: null });
+---
+
+<script>
+  const toggleButton = document.querySelector(
+    '.js-slide-toggle',
+  ) as HTMLElement;
+  const toc = document.querySelector('ol') as HTMLElement;
+
+  if (!toggleButton || !toc) throw new Error('toggleButton or toc not found');
+
+  document.addEventListener('DOMContentLoaded', () => {
+    toc.style.height = `${toc.scrollHeight}px`;
+  });
+
+  toggleButton.addEventListener('click', (e) => {
+    e.preventDefault();
+    const isOpen = toc.classList.toggle('is-open');
+
+    toggleButton.textContent = toc.classList.contains('is-open')
+      ? '非表示'
+      : '表示';
+
+    toc.style.height = isOpen ? `${toc.scrollHeight}px` : '0';
+  });
+</script>
+
+<div class="toc">
+  <p class="toc__title">目次 [<a class="js-slide-toggle">非表示</a>]</p>
+  <ol class="is-open">
+    {
+      headings
+        .filter((h) => h.depth < 3)
+        .map((h, i) => {
+          return (
+            <li class={`toc-level-${h.depth} toc-item`}>
+              <a href={`#${h.slug}`}>{h.text}</a>
+            </li>
+          );
+        })
+    }
+  </ol>
+</div>
+
+<style lang="scss">
+  .toc {
+    padding: 0.75rem;
+    background-color: #fff;
+    border: 1px solid #aaa;
+
+    &__title {
+      padding: 0;
+      margin: 0;
+      font-weight: bolder;
+
+      a:hover {
+        text-decoration: underline;
+        cursor: pointer;
+      }
+    }
+  }
+
+  ol {
+    margin: 0;
+    overflow: hidden;
+    list-style: none;
+    counter-reset: section;
+    transition: height 0.5s ease-in-out;
+  }
+
+  .toc-item {
+    counter-increment: section;
+
+    a:hover {
+      text-decoration: underline;
+    }
+
+    &.toc-level-1 {
+      margin-left: 1rem;
+      counter-reset: subsection;
+
+      a::before {
+        content: counters(section, '.') '. ';
+      }
+    }
+
+    &.toc-level-2 {
+      margin-left: 2.5rem;
+      counter-increment: subsection;
+
+      a::before {
+        content: counters(section, '.') '-' counters(subsection, '.') '. ';
+      }
+    }
+  }
+</style>

--- a/src/pages/posts/_components/Title/index.astro
+++ b/src/pages/posts/_components/Title/index.astro
@@ -1,0 +1,97 @@
+---
+type Props = {
+  title: string;
+  createdAt: Date;
+  updatedAt: Date;
+  category: string;
+  tags: string[];
+};
+
+const { title, createdAt, updatedAt, category, tags } = Astro.props;
+---
+
+<div class="container">
+  <h2 class="title">{title}</h2>
+
+  <p class="date">
+    <time datetime={createdAt.toLocaleDateString()}>
+      作成日:{createdAt.toLocaleDateString()}
+    </time>
+    <time datetime={updatedAt.toLocaleDateString()}>
+      更新日:{updatedAt.toLocaleDateString()}
+    </time>
+  </p>
+
+  <p class="category">
+    カテゴリー:<a href={`/portfolio/posts/category/${category}`}>
+      {category}
+    </a>
+  </p>
+
+  <ul class="tags">
+    <p>タグ一覧</p>
+    <div class="items">
+      {
+        tags.map((tag) => (
+          <li>
+            <a href={`/portfolio/posts/tag/${tag}`}>{tag}</a>
+          </li>
+        ))
+      }
+    </div>
+  </ul>
+</div>
+
+<style lang="scss">
+  .container {
+    padding: 5rem 1rem;
+    color: map-get($colors, 'white');
+    text-align: center;
+    background-color: rgba(map-get($colors, 'black'), 0.7);
+    @media screen and (width <= 768px) {
+      padding: 3rem 1rem;
+    }
+  }
+
+  .title {
+    font-size: 1.5rem;
+    @media screen and (width <= 768px) {
+      font-size: 1rem;
+    }
+  }
+
+  .date {
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
+    margin: 0.5rem;
+    font-size: 0.75rem;
+  }
+
+  .category {
+    margin: 0.5rem;
+    font-size: 0.875rem;
+  }
+
+  .tags {
+    max-width: 300px;
+    margin: 0.5rem auto;
+    font-size: 0.875rem;
+
+    .items {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      justify-content: center;
+    }
+  }
+
+  a {
+    color: map-get($colors, 'white');
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+</style>


### PR DESCRIPTION
# issueURL

#7 

# この PR で対応する範囲 / この PR で対応しない範囲

- ブログページを表示するための必要最低限なコンポーネント・Pageを実装
- 細かなスタイルは別ブランチで対応

# Storybook の URL、 スクリーンショット

ちょっとそれっぽくなってきた
![image](https://github.com/kuniyuki-f/portfolio/assets/9443634/55528a78-dbcb-42ff-b85f-afe644144d1e)


# 変更点概要

pages/posts/[slug].astro を実装した。
ディレクトリ構成は悩んだが、posts/_componentsディレクトリを切って、ブログ用のコンポーネントはここに配置するようにした。

# 補足情報

とくになし