### PR TITLE
ブログ詳細ページのスタイルを調整

### DIFF
--- a/src/pages/posts/[slug].astro
+++ b/src/pages/posts/[slug].astro
@@ -28,8 +28,8 @@ const { Content, headings } = await post.render();
       tags={post.data.tags}
     />
     <div class="content-wrapper">
+      <TOC headings={headings} />
       <div class="content">
-        <TOC headings={headings} />
         <Content />
       </div>
     </div>
@@ -43,6 +43,140 @@ const { Content, headings } = await post.render();
 
     @media screen and (width <= 768px) {
       padding: 1rem 2rem;
+    }
+  }
+
+  .content {
+    max-width: 1280px;
+    margin: 0 auto;
+
+    // 見出し
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6 {
+      padding-bottom: 5px; // 下線とテキストの間隔を調整
+      margin-top: 1.5em;
+      margin-bottom: 0.5em;
+      font-weight: bold;
+      border-bottom: 1px solid #ccc;
+    }
+
+    h1 {
+      font-size: 2em;
+      @media (width<= 768px) {
+        font-size: 1.5em;
+      }
+    }
+
+    h2 {
+      font-size: 1.75em;
+      @media (width<= 768px) {
+        font-size: 1.25em;
+      }
+    }
+
+    h3 {
+      font-size: 1.5em;
+      @media (width<= 768px) {
+        font-size: 1.125em;
+      }
+    }
+
+    h4 {
+      font-size: 1.25em;
+      @media (width<= 768px) {
+        font-size: 1em;
+      }
+    }
+
+    h5 {
+      font-size: 1.125em;
+      @media (width<= 768px) {
+        font-size: 1em;
+      }
+    }
+
+    h6 {
+      font-size: 1em;
+    }
+
+    // 強調
+    em {
+      font-style: italic;
+    }
+
+    strong {
+      font-weight: bold;
+    }
+
+    // リスト
+
+    ul {
+      margin-left: 1.75rem;
+      list-style-type: disc;
+
+      ul {
+        list-style-type: circle;
+
+        ul {
+          list-style-type: square;
+        }
+      }
+    }
+
+    ol {
+      margin-left: 2rem;
+      list-style-type: decimal;
+
+      ol {
+        list-style-type: lower-alpha;
+
+        ol {
+          list-style-type: lower-roman;
+        }
+      }
+    }
+
+    li {
+      margin-bottom: 0.5em;
+    }
+
+    // リンク
+    a {
+      color: map-get($colors, 'green');
+      text-decoration: none;
+
+      &:hover {
+        text-decoration: underline;
+      }
+    }
+
+    // 画像
+    img {
+      max-width: 100%;
+      height: auto;
+    }
+
+    // 引用
+    blockquote {
+      padding: 0.5em 10px;
+      margin: 1em 0;
+      color: #666;
+      border-left: 4px solid #ddd;
+    }
+
+    // コード
+    code {
+      padding: 0.2em 0.4em;
+    }
+
+    pre {
+      padding: 0.5em 1em;
+      margin: 1em 0;
+      border-radius: 0.3em;
     }
   }
 </style>

--- a/src/pages/posts/_components/TOC/index.astro
+++ b/src/pages/posts/_components/TOC/index.astro
@@ -52,7 +52,9 @@ console.dir(headings, { depth: null });
 
 <style lang="scss">
   .toc {
+    max-width: 1280px;
     padding: 0.75rem;
+    margin: auto;
     background-color: #fff;
     border: 1px solid #aaa;
 
@@ -60,11 +62,16 @@ console.dir(headings, { depth: null });
       padding: 0;
       margin: 0;
       font-weight: bolder;
+    }
+  }
 
-      a:hover {
-        text-decoration: underline;
-        cursor: pointer;
-      }
+  a {
+    color: map-get($colors, 'green');
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+      cursor: pointer;
     }
   }
 

--- a/src/pages/posts/_components/Title/index.astro
+++ b/src/pages/posts/_components/Title/index.astro
@@ -13,24 +13,13 @@ const { title, createdAt, updatedAt, category, tags } = Astro.props;
 <div class="container">
   <h2 class="title">{title}</h2>
 
-  <p class="date">
-    <time datetime={createdAt.toLocaleDateString()}>
-      作成日:{createdAt.toLocaleDateString()}
-    </time>
-    <time datetime={updatedAt.toLocaleDateString()}>
-      更新日:{updatedAt.toLocaleDateString()}
-    </time>
-  </p>
-
-  <p class="category">
-    カテゴリー:<a href={`/portfolio/posts/category/${category}`}>
-      {category}
-    </a>
-  </p>
-
-  <ul class="tags">
-    <p>タグ一覧</p>
+  <ul class="category-and-tags">
     <div class="items">
+      <li>
+        <a href={`/portfolio/posts/category/${category}`}>
+          {category}
+        </a>
+      </li>
       {
         tags.map((tag) => (
           <li>
@@ -40,48 +29,69 @@ const { title, createdAt, updatedAt, category, tags } = Astro.props;
       }
     </div>
   </ul>
+
+  <p class="date">
+    <time datetime={createdAt.toLocaleDateString()}>
+      <span> 公開日：</span>
+      <span>
+        {createdAt.toLocaleDateString()}
+      </span>
+    </time>
+    <time datetime={updatedAt.toLocaleDateString()}>
+      <span> 最終更新日：</span>
+      <span>
+        {updatedAt.toLocaleDateString()}
+      </span>
+    </time>
+  </p>
 </div>
 
 <style lang="scss">
   .container {
-    padding: 5rem 1rem;
+    padding: 4rem 1rem;
     color: map-get($colors, 'white');
     text-align: center;
-    background-color: rgba(map-get($colors, 'black'), 0.7);
+    background-color: rgb(0 0 0 / 70%);
     @media screen and (width <= 768px) {
       padding: 3rem 1rem;
     }
   }
 
   .title {
-    font-size: 1.5rem;
+    font-size: 2.5rem;
     @media screen and (width <= 768px) {
-      font-size: 1rem;
+      font-size: 1.5rem;
     }
   }
 
   .date {
     display: flex;
-    gap: 1rem;
-    justify-content: center;
+    flex-direction: column;
+    align-items: center;
     margin: 0.5rem;
     font-size: 0.75rem;
+
+    time {
+      display: grid;
+      grid-template-columns: 7em 10em;
+      justify-content: center;
+      width: 100%;
+
+      span:first-child {
+        text-align: right;
+      }
+    }
   }
 
-  .category {
-    margin: 0.5rem;
-    font-size: 0.875rem;
-  }
-
-  .tags {
-    max-width: 300px;
+  .category-and-tags {
+    max-width: 320px;
     margin: 0.5rem auto;
     font-size: 0.875rem;
 
     .items {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 0.5rem;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(6em, auto));
+      column-gap: 0.5rem;
       justify-content: center;
     }
   }


### PR DESCRIPTION
# issueURL

#7 

# この PR で対応する範囲 / この PR で対応しない範囲

- ブログ詳細ページの見た目を調整

# Storybook の URL、 スクリーンショット

![localhost_4321_portfolio_posts_template](https://github.com/kuniyuki-f/portfolio/assets/9443634/0b9d1658-6ddf-4318-b2bd-ba657e92f986)

# 変更点概要

DOM構造とスタイルを調整。機能面に変更はなし。

# 補足情報

以前と完全に同じ見た目、というわけではない、、、